### PR TITLE
add a simple github CI action to test build on PRs and pushes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,21 @@
+name: Build
+
+on:
+    - push
+    - pull_request
+
+jobs:
+    build:
+
+        runs-on: ubuntu-latest
+
+        steps:
+            - uses: actions/checkout@v2
+            - name: Dependencies
+              run: |
+                  sudo apt install -y lld nasm
+                  sudo ln -s /usr/bin/lld-link-9 /usr/bin/lld-link
+                  rustup default nightly
+                  rustup target add i586-pc-windows-msvc x86_64-pc-windows-msvc
+            - name: Compile
+              run: cargo run


### PR DESCRIPTION
this CI script will run as a github action on every git push and PR to this repo.

it simply runs an ubuntu image, installs dependencies, then executes `cargo run`.

[sample output](https://github.com/evanrichter/chocolate_milk/runs/606677550?check_suite_focus=true)