### PR TITLE
Fix removed feature from rust

### DIFF
--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -84,9 +84,10 @@ pub fn core_checkin() {
 
     // Transition from launched to online
     let old_state = APICS[core!().apic_id().unwrap() as usize]
-        .compare_and_swap(ApicState::Launched as u8,
+        .compare_exchange(ApicState::Launched as u8,
                           ApicState::Online   as u8,
-                          Ordering::SeqCst);
+                          Ordering::SeqCst,
+                          Ordering::SeqCst).unwrap_or_else(|x| x);
 
     if core!().id == 0 {
         // BSP should already be marked online

--- a/kernel/src/acpi.rs
+++ b/kernel/src/acpi.rs
@@ -56,12 +56,14 @@ static TOTAL_CORES: AtomicU32 = AtomicU32::new(0);
 /// List of all valid APICs on the system. The APIC ID is the index into the
 /// array, the array entry `AtomicU8` is the `u8` representation of an
 /// `ApicState` enum
+const ATOMICU8_APIC_STATE_INIT: AtomicU8 = AtomicU8::new(ApicState::None as u8);
 static APICS: [AtomicU8; MAX_CORES] =
-    [AtomicU8::new(ApicState::None as u8); MAX_CORES];
+    [ATOMICU8_APIC_STATE_INIT; MAX_CORES];
 
 /// Mappings of APIC IDs to their memory domains
+const ATOMICU8_INIT: AtomicU8 = AtomicU8::new(0);
 pub static APIC_TO_DOMAIN: [AtomicU8; MAX_CORES] =
-    [AtomicU8::new(0); MAX_CORES];
+    [ATOMICU8_INIT; MAX_CORES];
 
 /// Set the current execution state of a given APIC ID
 pub unsafe fn set_core_state(apic_id: u32, state: ApicState) {

--- a/kernel/src/interrupts.rs
+++ b/kernel/src/interrupts.rs
@@ -15,7 +15,8 @@ use crate::core_locals::LockInterrupts;
 
 /// If a given interrupt requires an EOI when it is handled, the corresponding
 /// offset into this table will indicate `true`.
-static EOI_REQUIRED: [AtomicBool; 256] = [AtomicBool::new(false); 256];
+const ATOMICBOOL_INIT: AtomicBool = AtomicBool::new(false);
+static EOI_REQUIRED: [AtomicBool; 256] = [ATOMICBOOL_INIT; 256];
 
 /// If set to `true`, EOIs will be handled where `EOI_REQUIRED` is set, and
 /// no handler will be invoked.

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1,7 +1,7 @@
 //! A kernel written all in Rust
 
 #![feature(panic_info_message, alloc_error_handler, llvm_asm, global_asm)]
-#![feature(const_in_array_repeat_expressions, const_generics, new_uninit)]
+#![feature(const_generics, new_uninit)]
 #![allow(incomplete_features)]
 
 #![no_std]

--- a/kernel/src/net/tcp.rs
+++ b/kernel/src/net/tcp.rs
@@ -71,9 +71,6 @@ pub struct TcpConnectionInt {
     /// Current acknowledge
     ack: u32,
 
-    /// Last observed sequence number from the remote side
-    remote_seq: u32,
-
     /// Last observed acknowledge number from the remote side
     remote_ack: u32,
 
@@ -222,7 +219,6 @@ impl TcpConnectionInt {
         }
 
         // Update the server state to the most recent packet information
-        self.remote_seq    = tcp.seq;
         self.remote_ack    = tcp.ack;
         self.remote_window = tcp.window;
 
@@ -463,7 +459,6 @@ impl NetDevice {
                     seq:           rand_seq,
                     ack:           0,
                     server:        server,
-                    remote_seq:    0,
                     remote_ack:    rand_seq,
                     remote_window: 0,
                     remote_mss:    536,

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -214,7 +214,8 @@ pub fn panic(info: &PanicInfo) -> ! {
     } else {
         // Check if the BSP is already panicing, if it is not, report our
         // panic to it via an NMI
-        if PANICING.compare_and_swap(false, true, Ordering::SeqCst) == false {
+        if PANICING.compare_exchange(false, true, Ordering::SeqCst,
+                        Ordering::SeqCst).unwrap_or_else(|x| x) == false {
             // Save the panic info for this core
             PANIC_PENDING.store(info as *const _ as *mut _, Ordering::SeqCst);
 

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -43,7 +43,7 @@ pub fn elapsed(start_time: u64) -> f64 {
 pub fn sleep(microseconds: u64) {
     let waitval = future(microseconds);
     while cpu::rdtsc() < waitval {
-        core::sync::atomic::spin_loop_hint();
+        core::hint::spin_loop();
     }
 }
 

--- a/shared/aht/src/lib.rs
+++ b/shared/aht/src/lib.rs
@@ -113,8 +113,9 @@ impl<K, V, const N: usize> Aht<K, V, N> {
             // Try to get exclusive access to this hash table entry
             if self.hash_table[hti].0.load(Ordering::SeqCst) == empty &&
                     self.hash_table[hti].0
-                        .compare_and_swap(empty, filling,
-                                          Ordering::SeqCst) == empty {
+                        .compare_exchange(empty, filling,
+                                          Ordering::SeqCst, Ordering::SeqCst)
+                        .unwrap_or_else(|x| x) == empty {
                 // Request the caller to create the entry
                 let ent = Box::into_raw(insert());
 

--- a/shared/atomicvec/src/lib.rs
+++ b/shared/atomicvec/src/lib.rs
@@ -63,8 +63,9 @@ impl<T, const N: usize> AtomicVec<T, N> {
             assert!(cur < N, "AtomicVec out of capacity");
 
             // Attempt to reserve this index
-            if self.in_use.compare_and_swap(cur, cur + 1,
-                                            Ordering::SeqCst) == cur {
+            if self.in_use.compare_exchange(cur, cur + 1,
+                                            Ordering::SeqCst, Ordering::SeqCst)
+                          .unwrap_or_else(|x| x) == cur {
                 break cur;
             }
         };

--- a/shared/lockcell/src/lib.rs
+++ b/shared/lockcell/src/lib.rs
@@ -7,7 +7,8 @@ use core::ops::{Deref, DerefMut};
 use core::cell::UnsafeCell;
 use core::panic::Location;
 use core::marker::PhantomData;
-use core::sync::atomic::{AtomicU32, AtomicU64, Ordering, spin_loop_hint};
+use core::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+use core::hint::spin_loop;
 
 /// Read the time stamp counter
 #[inline]
@@ -193,7 +194,7 @@ impl<T: ?Sized, I: InterruptState> LockCell<T, I> {
                 }
             }
 
-            spin_loop_hint();
+            spin_loop();
         }
 
         // Note that this core owns the lock


### PR DESCRIPTION
When trying to build chocolate_milk with the latest nightly rust it will fail. Currently it's using a feature that doesn't exist anymore. 

```
error[E0557]: feature has been removed
 --> src/main.rs:4:12
  |
4 | #![feature(const_in_array_repeat_expressions, const_generics, new_uninit)]
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ feature has been removed
  |
  = note: removed due to causing promotable bugs
```
Tested with: rustc 1.52.0-nightly (234781afe 2021-03-07)

This fix works without any problems, but maybe need some better naming of the new introduced consts. 