### PR TITLE
update asm, remove unused features

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,9 @@ jobs:
             - uses: actions/checkout@v2
             - name: Dependencies
               run: |
-                  sudo apt install -y lld-13 nasm
-                  sudo ln -s /usr/bin/lld-link-13 /usr/bin/lld-link
+                  sudo apt-get update
+                  sudo apt-get install -y lld-14 nasm
+                  sudo ln -s /usr/bin/lld-link-14 /usr/bin/lld-link
                   rustup default nightly
                   rustup target add i586-pc-windows-msvc x86_64-pc-windows-msvc
             - name: Compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
             - uses: actions/checkout@v2
             - name: Dependencies
               run: |
-                  sudo apt install -y lld-14 nasm
-                  sudo ln -s /usr/bin/lld-link-14 /usr/bin/lld-link
+                  sudo apt install -y lld-13 nasm
+                  sudo ln -s /usr/bin/lld-link-13 /usr/bin/lld-link
                   rustup default nightly
                   rustup target add i586-pc-windows-msvc x86_64-pc-windows-msvc
             - name: Compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ jobs:
             - name: Dependencies
               run: |
                   sudo apt-get update
-                  sudo apt-get install -y lld-14 nasm
-                  sudo ln -s /usr/bin/lld-link-14 /usr/bin/lld-link
+                  sudo apt-get install -y lld-12 nasm
+                  sudo ln -s /usr/bin/lld-link-12 /usr/bin/lld-link
                   rustup default nightly
                   rustup target add i586-pc-windows-msvc x86_64-pc-windows-msvc
             - name: Compile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
             - uses: actions/checkout@v2
             - name: Dependencies
               run: |
-                  sudo apt install -y lld nasm
-                  sudo ln -s /usr/bin/lld-link-9 /usr/bin/lld-link
+                  sudo apt install -y lld-14 nasm
+                  sudo ln -s /usr/bin/lld-link-14 /usr/bin/lld-link
                   rustup default nightly
                   rustup target add i586-pc-windows-msvc x86_64-pc-windows-msvc
             - name: Compile

--- a/bootloader/src/intrins.rs
+++ b/bootloader/src/intrins.rs
@@ -11,31 +11,7 @@
 // name mangling.
 // ---------------------------------------------------------------------------
 
-use core::arch::global_asm;
-
-/// Perform n % d
-#[export_name="\x01__aullrem"]
-pub extern "stdcall" fn __aullrem(n: u64, d: u64) -> u64 {
-    compiler_builtins::int::udiv::__umoddi3(n, d)
-}
-
-/// Perform n / d
-#[export_name="\x01__aulldiv"]
-pub extern "stdcall" fn __aulldiv(n: u64, d: u64) -> u64 {
-    compiler_builtins::int::udiv::__udivdi3(n, d)
-}
-
-/// Perform n % d
-#[export_name="\x01__allrem"]
-pub extern "stdcall" fn __allrem(n: i64, d: i64) -> i64 {
-    compiler_builtins::int::sdiv::__moddi3(n, d)
-}
-
-/// Perform n / d
-#[export_name="\x01__alldiv"]
-pub extern "stdcall" fn __alldiv(n: i64, d: i64) -> i64 {
-    compiler_builtins::int::sdiv::__divdi3(n, d)
-}
+use core::arch::{global_asm};
 
 global_asm!(r#"
     // eax -> Size of the stack allocation needed

--- a/bootloader/src/intrins.rs
+++ b/bootloader/src/intrins.rs
@@ -11,6 +11,8 @@
 // name mangling.
 // ---------------------------------------------------------------------------
 
+use core::arch::global_asm;
+
 /// Perform n % d
 #[export_name="\x01__aullrem"]
 pub extern "stdcall" fn __aullrem(n: u64, d: u64) -> u64 {
@@ -36,8 +38,6 @@ pub extern "stdcall" fn __alldiv(n: i64, d: i64) -> i64 {
 }
 
 global_asm!(r#"
-.intel_syntax
-
     // eax -> Size of the stack allocation needed
     .global __chkstk
     __chkstk:
@@ -48,10 +48,6 @@ global_asm!(r#"
 
         // Allocate the room on the stack as requested
         sub esp, eax
-
         // Jump to the return location
         jmp dword ptr [esp + eax]
-
-.att_syntax
 "#);
-

--- a/bootloader/src/main.rs
+++ b/bootloader/src/main.rs
@@ -1,7 +1,7 @@
 //! Bootloader for BIOS-based x86 implementations using PXE to download a
 //! second stage x86_64 PE file which will be loaded and executed in long mode
 
-#![feature(panic_info_message, rustc_private, alloc_error_handler, global_asm)]
+#![feature(panic_info_message, rustc_private, alloc_error_handler)]
 #![no_std]
 #![no_main]
 
@@ -61,6 +61,7 @@ pub static BOOT_ARGS: BootArgs<LockInterrupts> = BootArgs::new();
 #[no_mangle]
 extern fn entry(bootloader_end: usize, soft_reboot_entry: usize,
                 num_boots: u64) -> ! {
+
     // Initialize the serial driver
     {
         // Get access to the serial driver

--- a/kernel/src/core_locals.rs
+++ b/kernel/src/core_locals.rs
@@ -1,5 +1,6 @@
 //! This file is used to hold and access all of the core locals
 
+use core::arch::asm;
 use core::mem::size_of;
 use core::sync::atomic::{AtomicUsize, AtomicU8, AtomicU32, AtomicU64,Ordering};
 use core::alloc::Layout;
@@ -320,8 +321,7 @@ pub fn get_core_locals() -> &'static CoreLocals {
 
         // Get the first `u64` from `CoreLocals`, which given we don't change
         // the structure shape, should be the address of the core locals.
-        llvm_asm!("mov $0, gs:[0]" :
-             "=r"(ptr) :: "memory" : "volatile", "intel");
+        asm!("mov {0}, gs:[0]", out(reg) ptr);
 
         &*(ptr as *const CoreLocals)
     }

--- a/kernel/src/intrinsics.rs
+++ b/kernel/src/intrinsics.rs
@@ -3,6 +3,8 @@
 //! Since we build our kernel as a PE as an MSVC target it's required that
 //! we implement some of these intrinsics.
 
+use core::arch::global_asm;
+
 global_asm!(r#"
     .global __chkstk
     __chkstk:

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1,7 +1,7 @@
 //! A kernel written all in Rust
 
-#![feature(panic_info_message, alloc_error_handler, llvm_asm, global_asm)]
-#![feature(const_generics, new_uninit)]
+#![feature(panic_info_message, alloc_error_handler)]
+#![feature(new_uninit)]
 #![allow(incomplete_features)]
 
 #![no_std]

--- a/kernel/src/panic.rs
+++ b/kernel/src/panic.rs
@@ -1,5 +1,6 @@
 //! Panic handlers and soft reboots for the kernel
 
+use core::arch::asm;
 use core::fmt::Write;
 use core::panic::PanicInfo;
 use core::sync::atomic::{AtomicPtr, AtomicBool, Ordering};
@@ -113,7 +114,7 @@ pub unsafe fn soft_reboot(apic: &mut Apic) -> ! {
     let vmxon_lock = core!().vmxon_region().shatter();
     if (*vmxon_lock).is_some() {
         // Disable VMX root operation
-        llvm_asm!("vmxoff" :::: "intel", "volatile");
+        asm!("vmxoff");
     }
     
     // Convert the soft reboot virtual address into a function pointer that

--- a/shared/aht/src/lib.rs
+++ b/shared/aht/src/lib.rs
@@ -1,7 +1,6 @@
 //! Atomic hash table. Allows thread-safe atomic hash table insertions without
 //! needing locks
 
-#![feature(const_generics)]
 #![allow(incomplete_features)]
 #![no_std]
 

--- a/shared/atomicvec/src/lib.rs
+++ b/shared/atomicvec/src/lib.rs
@@ -1,7 +1,6 @@
 //! An atomic vector with a fixed size capacity and insert-only semantics
 
 #![no_std]
-#![feature(const_generics)]
 #![allow(incomplete_features)]
 
 extern crate alloc;

--- a/shared/boot_args/src/lib.rs
+++ b/shared/boot_args/src/lib.rs
@@ -7,7 +7,6 @@
 //! lives forever and is not deleted or moved by either the bootloader or
 //! kernel.
 
-#![feature(const_fn)]
 #![no_std]
 
 use core::sync::atomic::{AtomicU64, Ordering};

--- a/shared/cpu/src/lib.rs
+++ b/shared/cpu/src/lib.rs
@@ -1,7 +1,8 @@
 //! x86 CPU routines
 
-#![feature(llvm_asm)]
 #![no_std]
+
+use core::arch::asm;
 
 /// MSR for active FS base
 const IA32_FS_BASE: u32 = 0xc0000100;
@@ -12,53 +13,68 @@ const IA32_GS_BASE: u32 = 0xc0000101;
 /// Output an 8-bit `val` to I/O port `addr`
 #[inline]
 pub unsafe fn out8(addr: u16, val: u8) {
-    llvm_asm!("out dx, al" :: "{dx}"(addr), "{al}"(val) :: "volatile", "intel");
+    asm!(
+        "out dx, al",
+        in("dx") addr,
+        in("al") val,
+    );
 }
 
 /// Read an 8-bit value from I/O port `addr`
 #[inline]
 pub unsafe fn in8(addr: u16) -> u8 {
     let val: u8;
-    llvm_asm!("in al, dx" : "={al}"(val) : "{dx}"(addr) :: "volatile", "intel");
+    asm!(
+        "in al, dx",
+        in("dx") addr,
+        out("al") val,
+    );
     val
 }
 
 /// Output a 32-bit `val` to I/O port `addr`
 #[inline]
 pub unsafe fn out32(addr: u16, val: u32) {
-    llvm_asm!("out dx, eax" :: "{dx}"(addr), "{eax}"(val) :: "volatile", "intel");
+    asm!(
+        "out dx, eax",
+        in("dx") addr,
+        in("eax") val,
+    );
 }
 
 /// Read an 32-bit value from I/O port `addr`
 #[inline]
 pub unsafe fn in32(addr: u16) -> u32 {
     let val: u32;
-    llvm_asm!("in eax, dx" : "={eax}"(val) : "{dx}"(addr) :: "volatile", "intel");
+    asm!(
+        "in eax, dx",
+        out("eax") val,
+        in("dx") addr,
+    );
     val
 }
 
 /// Invalidate a page table entry
 #[inline]
 pub unsafe fn invlpg(vaddr: usize) {
-    llvm_asm!("invlpg [$0]" :: "r"(vaddr) : "memory" : "volatile", "intel");
+    asm!("invlpg [{0}]", in(reg) vaddr);
 }
-
 /// Flush a cache line containg `vaddr`
 #[inline]
 pub unsafe fn clflush(vaddr: usize) {
-    llvm_asm!("clflush [$0]" :: "r"(vaddr) : "memory" : "volatile", "intel");
+    asm!("clflush [{0}]", in(reg) vaddr);
 }
 
 /// Enable interrupts
 #[inline]
 pub unsafe fn enable_interrupts() {
-    llvm_asm!("sti" ::: "memory", "cc" : "volatile", "intel");
+    asm!("sti");
 }
 
 /// Disable interrupts
 #[inline]
 pub unsafe fn disable_interrupts() {
-    llvm_asm!("cli" ::: "memory", "cc" : "volatile", "intel");
+    asm!("cli");
 }
 
 /// Read an MSR
@@ -66,19 +82,24 @@ pub unsafe fn disable_interrupts() {
 pub unsafe fn rdmsr(msr: u32) -> u64 {
     let val_lo: u32;
     let val_hi: u32;
-    llvm_asm!("rdmsr" : "={edx}"(val_hi), "={eax}"(val_lo) : "{ecx}"(msr) :
-         "memory" : "volatile", "intel");
+    asm!(
+        "rdmsr",
+        out("edx") val_hi,
+        out("eax") val_lo,
+        in("ecx") msr,
+    );
     ((val_hi as u64) << 32) | val_lo as u64
 }
 
 /// Write an MSR
 #[inline]
 pub unsafe fn wrmsr(msr: u32, val: u64) {
-    llvm_asm!("wrmsr" ::
-         "{ecx}"(msr),
-         "{edx}"((val >> 32) as u32),
-         "{eax}"((val >>  0) as u32) :
-         "memory" : "volatile", "intel");
+    asm!(
+        "wrmsr",
+        in("ecx") msr,
+        in("edx") (val >> 32) as u32,
+        in("eax") (val >>  0) as u32,
+    );
 }
 
 /// Read the time stamp counter
@@ -88,8 +109,11 @@ pub fn rdtsc() -> u64 {
     let val_hi: u32;
 
     unsafe {
-        llvm_asm!("rdtsc" : "={edx}"(val_hi), "={eax}"(val_lo) ::
-             "memory" : "volatile", "intel");
+        asm!(
+            "rdtsc",
+            out("edx") val_hi,
+            out("eax") val_lo,
+        );
     }
 
     ((val_hi as u64) << 32) | val_lo as u64
@@ -123,9 +147,7 @@ pub unsafe fn set_fs_base(base: u64) {
 #[inline]
 pub fn single_halt() {
     unsafe {
-        llvm_asm!(r#"
-            hlt
-        "# :::: "volatile", "intel");
+        asm!("hlt");
     }
 }
 
@@ -134,9 +156,7 @@ pub fn single_halt() {
 pub fn halt() -> ! {
     unsafe {
         loop {
-            llvm_asm!(r#"
-                hlt
-            "# :::: "volatile", "intel");
+            asm!("hlt");
         }
     }
 }
@@ -153,114 +173,129 @@ pub fn canonicalize_address(addr: u64) -> u64 {
 pub unsafe fn cpuid(eax: u32, ecx: u32) -> (u32, u32, u32, u32) {
     let (oeax, oebx, oecx, oedx);
 
-    llvm_asm!("cpuid" :
-         "={eax}"(oeax), "={ebx}"(oebx), "={ecx}"(oecx), "={edx}"(oedx) :
-         "{eax}"(eax), "{ecx}"(ecx) :: "volatile", "intel");
+    asm!(
+        "cpuid",
+        "mov {:e}, ebx",
+        // ebx cannot be used directly by asm
+        out(reg) oebx,
+        inout("eax") eax => oeax,
+        inout("ecx") ecx => oecx,
+        out("edx") oedx,
+    );
 
     (oeax, oebx, oecx, oedx)
 }
 
-/// Read `cr0`
-#[inline]
-pub fn read_cr0() -> u64 {
-    let val: u64;
-    unsafe {
-        llvm_asm!("mov $0, cr0" : "=r"(val) :: "memory" : "volatile", "intel");
+#[cfg(target_arch="x86_64")]
+mod x86_64 {
+    use core::arch::asm;
+
+    /// Read `cr0`
+    #[inline]
+    pub fn read_cr0() -> u64 {
+        let val: u64;
+        unsafe {
+            asm!("mov {0}, cr0", out(reg) val);
+        }
+        val
     }
-    val
-}
 
-/// Write to `cr0`
-#[inline]
-pub unsafe fn write_cr0(val: u64) {
-    llvm_asm!("mov cr0, $0" :: "r"(val) : "memory" : "volatile", "intel");
-}
-
-/// Read `cr2`
-#[inline]
-pub fn read_cr2() -> u64 {
-    let val: u64;
-    unsafe {
-        llvm_asm!("mov $0, cr2" : "=r"(val) :: "memory" : "volatile", "intel");
+    /// Write to `cr0`
+    #[inline]
+    pub unsafe fn write_cr0(val: u64) {
+        asm!("mov cr0, {0}", in(reg) val);
     }
-    val
-}
 
-/// Write to `cr2`
-#[inline]
-pub unsafe fn write_cr2(val: u64) {
-    llvm_asm!("mov cr2, $0" :: "r"(val) : "memory" : "volatile", "intel");
-}
-
-/// Read `cr3`
-#[inline]
-pub fn read_cr3() -> u64 {
-    let val: u64;
-    unsafe {
-        llvm_asm!("mov $0, cr3" : "=r"(val) :: "memory" : "volatile", "intel");
+    /// Read `cr2`
+    #[inline]
+    pub fn read_cr2() -> u64 {
+        let val: u64;
+        unsafe {
+            asm!("mov {0}, cr2", out(reg) val);
+        }
+        val
     }
-    val
-}
 
-/// Write to `cr3`
-#[inline]
-pub unsafe fn write_cr3(val: u64) {
-    llvm_asm!("mov cr3, $0" :: "r"(val) : "memory" : "volatile", "intel");
-}
-
-/// Read `cr4`
-#[inline]
-pub fn read_cr4() -> u64 {
-    let val: u64;
-    unsafe {
-        llvm_asm!("mov $0, cr4" : "=r"(val) :: "memory" : "volatile", "intel");
+    /// Write to `cr2`
+    #[inline]
+    pub unsafe fn write_cr2(val: u64) {
+        asm!("mov cr2, {0}", in(reg) val);
     }
-    val
-}
 
-/// Write to `cr4`
-#[inline]
-pub unsafe fn write_cr4(val: u64) {
-    llvm_asm!("mov cr4, $0" :: "r"(val) : "memory" : "volatile", "intel");
-}
-
-/// Read `cr8`
-#[inline]
-pub fn read_cr8() -> u64 {
-    let val: u64;
-    unsafe {
-        llvm_asm!("mov $0, cr8" : "=r"(val) :: "memory" : "volatile", "intel");
+    /// Read `cr3`
+    #[inline]
+    pub fn read_cr3() -> u64 {
+        let val: u64;
+        unsafe {
+            asm!("mov {0}, cr3", out(reg) val);
+        }
+        val
     }
-    val
-}
 
-/// Write to `cr8`
-#[inline]
-pub unsafe fn write_cr8(val: u64) {
-    llvm_asm!("mov cr8, $0" :: "r"(val) : "memory" : "volatile", "intel");
-}
-
-/// Read `dr6`
-#[inline]
-pub fn read_dr6() -> u64 {
-    let val: u64;
-    unsafe {
-        llvm_asm!("mov $0, dr6" : "=r"(val) :: "memory" : "volatile", "intel");
+    /// Write to `cr3`
+    #[inline]
+    pub unsafe fn write_cr3(val: u64) {
+        asm!("mov cr3, {0}", in(reg) val);
     }
-    val
+
+    /// Read `cr4`
+    #[inline]
+    pub fn read_cr4() -> u64 {
+        let val: u64;
+        unsafe {
+            asm!("mov {0}, cr4", out(reg) val);
+        }
+        val
+    }
+
+    /// Write to `cr4`
+    #[inline]
+    pub unsafe fn write_cr4(val: u64) {
+        asm!("mov cr4, {0}", in(reg) val);
+    }
+
+    /// Read `cr8`
+    #[inline]
+    pub fn read_cr8() -> u64 {
+        let val: u64;
+        unsafe {
+            asm!("mov {0}, cr8", out(reg) val);
+        }
+        val
+    }
+
+    /// Write to `cr8`
+    #[inline]
+    pub unsafe fn write_cr8(val: u64) {
+        asm!("mov cr8, {0}", in(reg) val);
+    }
+
+
+    /// Read `dr6`
+    #[inline]
+    pub fn read_dr6() -> u64 {
+        let val: u64;
+        unsafe {
+            asm!("mov {0}, dr6", out(reg) val);
+        }
+        val
+    }
+
+    /// Write to `dr6`
+    #[inline]
+    pub unsafe fn write_dr6(val: u64) {
+        asm!("mov dr6, {0}", in(reg) val);
+    }
 }
 
-/// Write to `dr6`
-#[inline]
-pub unsafe fn write_dr6(val: u64) {
-    llvm_asm!("mov dr6, $0" :: "r"(val) : "memory" : "volatile", "intel");
-}
+#[cfg(target_arch="x86_64")]
+pub use x86_64::*;
 
 /// Gets the ES selector value
 #[inline]
 pub unsafe fn read_es() -> u16 {
     let ret;
-    llvm_asm!("mov $0, es" : "=r"(ret) ::: "intel", "volatile");
+    asm!("mov {0:x}, es", out(reg) ret);
     ret
 }
 
@@ -268,7 +303,7 @@ pub unsafe fn read_es() -> u16 {
 #[inline]
 pub unsafe fn read_cs() -> u16 {
     let ret;
-    llvm_asm!("mov $0, cs" : "=r"(ret) ::: "intel", "volatile");
+    asm!("mov {0:x}, cs", out(reg) ret);
     ret
 }
 
@@ -276,7 +311,7 @@ pub unsafe fn read_cs() -> u16 {
 #[inline]
 pub unsafe fn read_ss() -> u16 {
     let ret;
-    llvm_asm!("mov $0, ss" : "=r"(ret) ::: "intel", "volatile");
+    asm!("mov {0:x}, ss", out(reg) ret);
     ret
 }
 
@@ -284,7 +319,7 @@ pub unsafe fn read_ss() -> u16 {
 #[inline]
 pub unsafe fn read_ds() -> u16 {
     let ret;
-    llvm_asm!("mov $0, ds" : "=r"(ret) ::: "intel", "volatile");
+    asm!("mov {0:x}, ds", out(reg) ret);
     ret
 }
 
@@ -292,7 +327,7 @@ pub unsafe fn read_ds() -> u16 {
 #[inline]
 pub unsafe fn read_fs() -> u16 {
     let ret;
-    llvm_asm!("mov $0, fs" : "=r"(ret) ::: "intel", "volatile");
+    asm!("mov {0:x}, fs", out(reg) ret);
     ret
 }
 
@@ -300,7 +335,7 @@ pub unsafe fn read_fs() -> u16 {
 #[inline]
 pub unsafe fn read_gs() -> u16 {
     let ret;
-    llvm_asm!("mov $0, gs" : "=r"(ret) ::: "intel", "volatile");
+    asm!("mov {0:x}, gs", out(reg) ret);
     ret
 }
 
@@ -308,8 +343,10 @@ pub unsafe fn read_gs() -> u16 {
 #[inline]
 pub unsafe fn read_tr() -> u16 {
     let mut ret: u16 = 0;
-    llvm_asm!("str [$0]" :: "r"(&mut ret as *mut u16) : "memory" :
-              "intel", "volatile");
+    asm!(
+        "str [{0}]",
+        in(reg) &mut ret as *mut u16,
+    );
     ret
 }
 
@@ -318,7 +355,11 @@ pub unsafe fn read_tr() -> u16 {
 #[cfg(target_arch = "x86_64")]
 pub unsafe fn flags() -> u64 {
     let val: u64;
-    llvm_asm!("pushfq ; pop $0" : "=r"(val) :: "memory" : "volatile", "intel");
+    asm!(
+        "pushfq",
+        "pop {0}",
+        out(reg) val,
+    );
     val
 }
 
@@ -329,12 +370,13 @@ pub fn delay(cycles: u64) {
     if cycles <= 0 { return; }
 
     unsafe {
-        llvm_asm!(r#"
-            mov rax, $0
+        asm!(r#"
         2:
             dec rax
             jnz 2b
-        "# :: "r"(cycles) : "rax", "memory", "cc" : "volatile", "intel");
+        "#,
+            inout("rax") cycles => _,
+        );
     }
 }
 
@@ -436,4 +478,3 @@ pub fn get_cpu_features() -> CPUFeatures {
 
     features
 }
-

--- a/shared/lockcell/src/lib.rs
+++ b/shared/lockcell/src/lib.rs
@@ -1,8 +1,7 @@
 //! Inner-mutability on shared variables through spinlocks
-
 #![no_std]
-#![feature(const_fn, llvm_asm)]
 
+use core::arch::asm;
 use core::ops::{Deref, DerefMut};
 use core::cell::UnsafeCell;
 use core::panic::Location;
@@ -17,8 +16,11 @@ pub fn rdtsc() -> u64 {
     let val_hi: u32;
 
     unsafe {
-        llvm_asm!("rdtsc" : "={edx}"(val_hi), "={eax}"(val_lo) ::
-             "memory" : "volatile", "intel");
+        asm!(
+            "rdtsc",
+            out("edx") val_hi,
+            out("eax") val_lo,
+        );
     }
 
     ((val_hi as u64) << 32) | val_lo as u64

--- a/shared/noodle/src/lib.rs
+++ b/shared/noodle/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg_attr(not(feature = "std"), no_std)]
-#![feature(const_generics)]
 #![allow(incomplete_features)]
 
 extern crate core;


### PR DESCRIPTION
This is an incomplete pull request to update `asm!` blocks.
~~Currently bootloader doesn't build with errors related to u64 div/rem symbols.~~ it just werks